### PR TITLE
Use explicit argument to `sqrt()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -135,7 +135,7 @@ tests <- function() {
 }
 
 nested_tests <- function() {
-  tests() %>% sqrt() %>% round()
+  tests() %>% sqrt(x = .) %>% round()
 }
 
 assert_modifiable_length <- function(generator) {


### PR DESCRIPTION
I'm actually uncertain as to why this doesn't raise an issue during check, but it otherwise raises a Note on install.

Closes #19